### PR TITLE
Discard master-slave vocabulary

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,8 +38,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'python-fitparse'

--- a/fitparse/profile.py
+++ b/fitparse/profile.py
@@ -1519,7 +1519,7 @@ FIELD_TYPES = {
             101: 'length',
             103: 'monitoring_info',
             105: 'pad',
-            106: 'slave_device',
+            106: 'subordinate_device',
             127: 'connectivity',
             128: 'weather_conditions',
             129: 'weather_alert',
@@ -1729,7 +1729,7 @@ FIELD_TYPES = {
             43: 'windsurfing',
             44: 'kitesurfing',
             45: 'tactical',
-            46: 'jumpmaster',
+            46: 'jumpmain',
             47: 'boxing',
             48: 'floor_climbing',
             254: 'all',  # All is for goals only to include all sports.
@@ -1815,7 +1815,7 @@ FIELD_TYPES = {
             0x08: 'windsurfing',
             0x10: 'kitesurfing',
             0x20: 'tactical',
-            0x40: 'jumpmaster',
+            0x40: 'jumpmain',
             0x80: 'boxing',
         },
     ),
@@ -6422,7 +6422,7 @@ MESSAGE_TYPES = {
         },
     ),
     106: MessageType(
-        name='slave_device',
+        name='subordinate_device',
         mesg_num=106,
         fields={
             0: Field(


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.